### PR TITLE
Fix issue where accessKey isn't passed into client config

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,8 +41,8 @@ function Client (opts) {
   self.logs = new Logs(self);
   self.domains = new Domains(self);
 
-  if (config.accessKey) {
-    self.hook_private_key = config.accessKey;
+  if (opts.accessKey) {
+    self.hook_private_key = opts.accessKey;
     self.attemptAuth = true;
   }
   if (opts.hook_private_key) {


### PR DESCRIPTION
I might be missing something but the docs suggest the following snippet should work:

``` js
var client = sdk.createClient({
  accessKey: 'private-key'
})
```

However the private key doesn't get sent with requests, and thus requests aren't authenticated. The patch here fixes this.

---

As a work around this currently behaves as expected:

``` js
var client = sdk.createClient({
  hook_private_key: 'private-key'
})
```
