### PR TITLE
GH-3: keep hook_private_key away from logged parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,10 +82,13 @@ Client.prototype.request = function (url, opts, cb) {
   url =  self.protocol + "://" + self.host + ":" + self.port + url;
   opts.json = opts.json || {};
   if (self.attemptAuth === true) {
-    if (opts.json === true) {
-      opts.json = {};
+    if (!opts.headers) {
+      opts.headers = {};
     }
-    opts.json.hook_private_key = opts.json.hook_private_key || self.hook_private_key;
+    opts.headers.hook_private_key = opts.json.hook_private_key || self.hook_private_key;
+    if (opts.json && opts.json.hook_private_key !== undefined) {
+        delete opts.json.hook_private_key;
+    }
   }
 
   // TODO: add ability to extend other endpoints besides files


### PR DESCRIPTION
Assuming

``` console
# export hook_private_key=12345
```

Before:

``` console
# node bin/hook marak/echo
{ hook_private_key: '12345', param1: 'foo', param2: 'bar' }
```

After

``` console
# node bin/hook marak/echo
{ param1: 'foo', param2: 'bar' }
```

Also compare logs:
before

``` json
[
  {"time":"2016-05-13T20:09:22.114Z","data":"\"POST\"","ip":"127.0.0.1"},
  {"time":"2016-05-13T20:09:22.114Z","data":"\"/marak/echo\"","ip":"127.0.0.1"},
  {"time":"2016-05-13T20:09:22.114Z","data":"{\"hook_private_key\":\"12345\",\"param1\":\"foo\",\"param2\":\"bar\"}","ip":"127.0.0.1"},
  {"time":"2016-05-13T20:09:22.113Z","data":"\"Console messages are sent to /logs\"","ip":"127.0.0.1"},
  {"time":"2016-05-13T20:08:39.887Z","data":"{\"env1\":\"val1\",\"hello2\":\"there\",\"hookAccessKey\":\"51b8f3cd-eb23-45ab-84be-8e0e1f5a161a\"}","ip":"127.0.0.1"}
]
```

after

``` json
[
  {"time":"2016-05-13T20:08:39.887Z","data":"\"POST\"","ip":"127.0.0.1"},
  {"time":"2016-05-13T20:08:39.886Z","data":"\"/marak/echo\"","ip":"127.0.0.1"},
  {"time":"2016-05-13T20:08:39.886Z","data":"{\"param1\":\"foo\",\"param2\":\"bar\"}","ip":"127.0.0.1"},
  {"time":"2016-05-13T20:08:39.882Z","data":"\"Console messages are sent to /logs\"","ip":"127.0.0.1"},
  {"time":"2016-05-13T20:08:32.468Z","data":"{\"env1\":\"val1\",\"hello2\":\"there\",\"hookAccessKey\":\"51b8f3cd-eb23-45ab-84be-8e0e1f5a161a\"}","ip":"127.0.0.1"}
]
```

Obviously if one outputs `hook.req.headers` to logs this will not help, but this can be additionally documented.
